### PR TITLE
Changed trelora_service to updated endpoint

### DIFF
--- a/app/services/trelora_service.rb
+++ b/app/services/trelora_service.rb
@@ -27,6 +27,6 @@ class TreloraService
   end
 
   def conn
-    Faraday.new(url: "https://www.trylora.com")
+    Faraday.new(url: "https://trylora.herokuapp.com/")
   end
 end


### PR DESCRIPTION
Just changed the endpoint of the Trelora API to the new one: https://trylora.herokuapp.com/